### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@critik/simple-webdriver",
-  "version": "0.9.0-dev1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@critik/simple-webdriver",
-      "version": "0.9.0-dev1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/chai": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@critik/simple-webdriver",
-  "version": "0.9.0-dev1",
+  "version": "0.9.0",
   "description": "Javascript webdriver bindings with no dependency",
   "keywords": [
     "webdriver",


### PR DESCRIPTION
## Summary

Bumps the package version from `0.9.0-dev1` → `0.9.0`, finalizing the release that ships the CDP backend (#279).

The PR #279 ([squash-]merged on 2026-06-03) brought the feature work in but the release commit was left on the merged-then-archived feature branch. This PR ports it to `main` on its own so it can land cleanly.

## Diff

- `package.json` : `0.9.0-dev1` → `0.9.0`
- `package-lock.json` : same (top-level + root package entry)

## Release notes (0.4.0 → 0.9.0)

### ✨ New
- **Chrome DevTools Protocol backend.** Pilot Chromium directly without an external driver binary via `WebDriver.cdp({ browser, headless, ... })`.
- New static factories `WebDriver.w3c(url)` and `WebDriver.cdp(options)`.
- New exports: `CDPOptions`, `CDPBrowser`, `CDPNotImplementedError`.

### ♻️ Refactor
- All operations route through a new `ProtocolDriver` interface. The W3C HTTP backend is unchanged on the wire — `W3CDriver` is a thin wrapper around the existing request builder + http-client.

### ⚠️ Breaking
- `Protocol.JSONWire` now throws on construction (was silently falling back to W3C). Use `Protocol.W3C` or the new factories instead.

### 📛 Deprecated
- `new WebDriver(url, protocol)` is deprecated. Use `WebDriver.w3c(url)` (or `.cdp(options)`). Still works for now.

### 📋 Requirements
- W3C mode: Node 18+ (unchanged).
- CDP mode: Node 22.4+ (uses the global `WebSocket`). Chromium / Chrome / Edge supported; Firefox & Safari stay on W3C.

## Test plan
- [x] `npm test` — 905 passing
- [x] `npm run lint` — 0 warnings
- [x] `npm run test-cdp-chrome` against a real Chrome — 8/8 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)