### PR TITLE
fix(http-client): bundler-safe createRequire (0.9.1)

### DIFF
--- a/src/utils/http-client.ts
+++ b/src/utils/http-client.ts
@@ -3,10 +3,17 @@ import { createRequire } from 'module'
 import type * as httpTypes from 'http'
 import type * as httpsTypes from 'https'
 
-// Use createRequire to load http/https as CJS modules.
-// This ensures the returned objects are mutable, allowing
-// test libraries like nock to intercept requests.
-const require = createRequire(import.meta.url)
+// We need http/https loaded via CJS require so that interception
+// libraries (nock & co) can swap out the module's exports. Using
+// `import * as http from 'http'` returns a frozen namespace object
+// that those libraries cannot patch, and `await import('http')`
+// suffers from the same restriction in ESM.
+//
+// `createRequire` needs an anchor that resolves to an existing path —
+// it does NOT need to be the file requesting the require. We use
+// `process.execPath` so that bundlers like esbuild that stub
+// `import.meta.url` as an empty object can't trip us up.
+const require = createRequire(process.execPath)
 const http = require('http') as typeof httpTypes
 const https = require('https') as typeof httpsTypes
 


### PR DESCRIPTION
## Summary

Patch release **0.9.1** that fixes a bundler-time crash hit by downstream apps consuming \`@critik/simple-webdriver\` with esbuild (or any bundler that emits CJS with \`--platform=node --format=cjs\`):

\`\`\`
TypeError: the argument 'filename' must be a file URL object,
           a file URL string, or an absolute path string
    at new NodeError ...
    at createRequire ...
    at dist/utils/http-client.js
\`\`\`

## Cause

esbuild stubs \`import.meta\` as an empty object literal (\`var import_meta = {}\`), so \`import.meta.url\` is \`undefined\` at runtime, and \`createRequire(undefined)\` throws.

## Fix

Anchor \`createRequire\` on \`process.execPath\` instead of \`import.meta.url\`:

\`\`\`ts
const require = createRequire(process.execPath)
const http = require('http') as typeof httpTypes
const https = require('https') as typeof httpsTypes
\`\`\`

\`createRequire\` only needs a valid path to anchor module resolution from. For bare specifiers like \`http\` / \`https\` the anchor is functionally irrelevant. \`process.execPath\` is always a defined string in Node and bundlers don't rewrite it.

## Why keep createRequire at all?

Tested briefly with plain ESM \`import * as http from 'http'\` — 56 tests fail. nock 14 (via \`@mswjs/interceptors\`) still needs the mutable \`require('http')\` shape to swap out \`http.request\` at runtime; ESM namespace objects are frozen.

The expanded comment in the file explains the rationale to future readers.

## Test plan

- [x] \`npm test\` — 905 passing, 0 failing
- [x] \`tsc --noEmit\` clean
- [x] \`npm pack --dry-run\` previews \`@critik/simple-webdriver-0.9.1.tgz\`

## Release flow

1. Merge this PR
2. \`npm publish\` from main → publishes 0.9.1
3. Users upgrade with \`npm install @critik/simple-webdriver@latest\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)